### PR TITLE
Password is now trimmed before checking length, closes #5

### DIFF
--- a/source/EzPasswordValidator/Checks/LengthCheck.cs
+++ b/source/EzPasswordValidator/Checks/LengthCheck.cs
@@ -41,8 +41,10 @@
         /// <inheritdoc />
         /// <summary>
         /// Checks if the given password is equal to or longer than the required minimum length.
+        /// The password is trimmed (trailing and leading white space is removed) before checking length.
+        /// <c>null</c> is always invalid.
         /// </summary>
         protected override bool OnExecute(string password) =>
-            !string.IsNullOrWhiteSpace(password) && password.Length >= RequiredLength;
+            !string.IsNullOrWhiteSpace(password) && password.Trim().Length >= RequiredLength;
     }
 }


### PR DESCRIPTION
Leading and trailing white space is removed before checking length.

# Description

Closes issue of incorrectly calculating length.

Fixes #5 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


