### PR TITLE
Support for other alphabets #8

### DIFF
--- a/source/EzPasswordValidator.Tests/CaseCheckTest.cs
+++ b/source/EzPasswordValidator.Tests/CaseCheckTest.cs
@@ -21,6 +21,15 @@ namespace EzPasswordValidator.Tests
         public void WhenPasswordHasUpperAndLowerEnglishCharsThenPasswordIsValid(string validPsw) => 
             Assert.IsTrue(_check.Execute(validPsw));
 
+        /// <summary>The case check should support non-english alphabet characters.</summary>
+        [DataRow("øøÆÆ")]
+        [DataRow("ÅÅøø")]
+        [DataRow("æØæ")]
+        [DataRow("ÆøÅ")]
+        [DataTestMethod]
+        public void WhenPasswordHasUpperAndLowerNonEnglishCharsThenPasswordIsValid(string validPsw) =>
+            Assert.IsTrue(_check.Execute(validPsw));
+
         [TestMethod]
         public void WhenPasswordHasOnlyUpperCaseCharsThenPasswordIsNotValid()
         {

--- a/source/EzPasswordValidator.Tests/LetterCheckTest.cs
+++ b/source/EzPasswordValidator.Tests/LetterCheckTest.cs
@@ -14,6 +14,9 @@ namespace EzPasswordValidator.Tests
         [DataRow("A12345")]
         [DataRow("12345A")]
         [DataRow("123A45")]
+        [DataRow("Ø12345")]
+        [DataRow("12345Ø")]
+        [DataRow("123Ø45")]
         [DataTestMethod]
         public void WhenPasswordContainsExactlyOneLetterThenPasswordIsValid(string validPsw) => 
             Assert.IsTrue(_check.Execute(validPsw));
@@ -21,6 +24,7 @@ namespace EzPasswordValidator.Tests
         [DataRow("ABC")]
         [DataRow("bbb")]
         [DataRow("aBc")]
+        [DataRow("æÅø")]
         [DataTestMethod]
         public void WhenPasswordContainsOnlyLettersThenPasswordIsValid(string validPsw) =>
             Assert.IsTrue(_check.Execute(validPsw));

--- a/source/EzPasswordValidator.Tests/LetterRepetitionCheckTest.cs
+++ b/source/EzPasswordValidator.Tests/LetterRepetitionCheckTest.cs
@@ -15,6 +15,7 @@ namespace EzPasswordValidator.Tests
         [DataRow("testAA")]
         [DataRow("teAAst")]
         [DataRow("AAtest")]
+        [DataRow("ØØtest")] //Non ISO basic latin test case
         [DataTestMethod]
         public void WhenPasswordContainsTheSameLetterTwoTimesInARowThenPasswordIsValid(string psw) => 
             Assert.IsTrue(_check.Execute(psw));
@@ -22,6 +23,7 @@ namespace EzPasswordValidator.Tests
         [DataRow("testAAA")]
         [DataRow("teAAAst")]
         [DataRow("AAAtest")]
+        [DataRow("ØØØtest")] //Non ISO basic latin test case
         [DataTestMethod]
         public void WhenPasswordContainsTheSameLetterThreeTimesInARowThenPasswordIsInvalid(string psw) => 
             Assert.IsFalse(_check.Execute(psw));

--- a/source/EzPasswordValidator.Tests/SymbolRepetitionCheckTest.cs
+++ b/source/EzPasswordValidator.Tests/SymbolRepetitionCheckTest.cs
@@ -26,14 +26,22 @@ namespace EzPasswordValidator.Tests
         public void WhenPasswordContainsSymbolRepetitionOfLengthTwoThenPasswordIsValid(string psw) => 
             Assert.IsTrue(_check.Execute(psw));
 
-        [DataRow("test///")]
-        [DataRow("///test")]
-        [DataRow("te///st")]
+        [DataRow("test$///")]
+        [DataRow("$///test")]
+        [DataRow("te///$st")]
         [DataRow("test#####")]
         [DataRow("#####test")]
         [DataRow("te#####st")]
         [DataTestMethod]
         public void WhenPasswordContainsSymbolRepetitionOfLengthThreeOrLongerThenPasswordIsValid(string psw) => 
             Assert.IsFalse(_check.Execute(psw));
+
+        [TestMethod]
+        public void WhenPasswordContainsThreeDifferentSymbolsInSequenceThenPasswordIsInvalid()
+        {
+            const string psw = "test@#$";
+
+            Assert.IsTrue(_check.Execute(psw));
+        }
     }
 }

--- a/source/EzPasswordValidator/Checks/CaseCheck.cs
+++ b/source/EzPasswordValidator/Checks/CaseCheck.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Linq;
 
 namespace EzPasswordValidator.Checks
 {
@@ -22,6 +22,7 @@ namespace EzPasswordValidator.Checks
         /// Checks that the password contains at least one upper- and lower-case letter.
         /// </summary>
         protected override bool OnExecute(string password) =>
-            Regex.IsMatch(password, "^.*([a-z]+.*[A-Z]+|[A-Z]+.*[a-z]+)+.*$");
+            password.Any(char.IsUpper) && password.Any(char.IsLower);
+
     }
 }

--- a/source/EzPasswordValidator/Checks/LetterCheck.cs
+++ b/source/EzPasswordValidator/Checks/LetterCheck.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.RegularExpressions;
-
+﻿
 namespace EzPasswordValidator.Checks
 {
     /// <inheritdoc />
@@ -23,7 +22,17 @@ namespace EzPasswordValidator.Checks
         /// <summary>
         /// Checks that the password contains at least one letter.
         /// </summary>
-        protected override bool OnExecute(string password) => 
-            Regex.IsMatch(password, "^.*[A-Za-z]+.*$");
+        protected override bool OnExecute(string password)
+        {
+            foreach (char c in password)
+            {
+                if (char.IsLetter(c))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
     }
 }

--- a/source/EzPasswordValidator/Checks/LetterRepetitionCheck.cs
+++ b/source/EzPasswordValidator/Checks/LetterRepetitionCheck.cs
@@ -26,7 +26,37 @@ namespace EzPasswordValidator.Checks
         /// <returns>
         ///   <c>true</c> if the password does NOT contain letter repetition; <c>false</c> otherwise.
         /// </returns>
-        protected override bool OnExecute(string password) =>
-            !Regex.IsMatch(password, @"^.*([A-Za-z])\1{2}.*$", RegexOptions.IgnoreCase); 
+        protected override bool OnExecute(string password)
+        {
+            const char baseChar = (char)0;
+            char previousPrevious = baseChar;
+            char previous = baseChar;
+            foreach (char c in password)
+            {
+                if (char.IsLetter(c))
+                {
+                    if (previousPrevious == baseChar || previousPrevious != c)
+                    {
+                        previousPrevious = c;
+                    }
+                    else if (previous == baseChar || previous != c)
+                    {
+                        previous = c;
+                    }
+                    else
+                    {
+                        if (previousPrevious == previous && previous == c)
+                        {
+                            return false;
+                        }
+                    }
+                    continue;
+                }
+
+                previousPrevious = baseChar;
+                previous = baseChar;
+            }
+            return true;
+        }
     }
 }

--- a/source/EzPasswordValidator/Checks/LetterSequenceCheck.cs
+++ b/source/EzPasswordValidator/Checks/LetterSequenceCheck.cs
@@ -20,7 +20,8 @@ namespace EzPasswordValidator.Checks
         /// <inheritdoc />
         /// <summary>
         /// Checks if the password contains an alphabetical letter sequence consisting of four or more
-        /// characters. Two common three letter sequences are added: abc and xyz.
+        /// characters. Two common three letter sequences are added: abc and xyz. Note that this check
+        /// only supports ISO basic latin alphabet (A-Za-z).
         /// </summary>
         /// <returns>
         ///   <c>true</c> if the password does NOT contain a letter sequence; <c>false</c> otherwise.

--- a/source/EzPasswordValidator/Checks/SymbolCheck.cs
+++ b/source/EzPasswordValidator/Checks/SymbolCheck.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Collections.Generic;
 
 namespace EzPasswordValidator.Checks
 {
@@ -9,6 +9,13 @@ namespace EzPasswordValidator.Checks
     /// <seealso cref="EzPasswordValidator.Checks.Check" />
     public sealed class SymbolCheck : Check
     {
+
+        public static HashSet<char> SymbolsHashSet = new HashSet<char>(new[]
+        {
+            '~','!','@','#','$','%','^','&','*','(',')','_','-','+','=','[','{','}',']','\'','"',';',
+            ':','/','?','<','>',',','.','`','£','§','€'
+        });
+
         /// <inheritdoc />
         /// <summary>
         /// Initializes a new instance of the <see cref="EzPasswordValidator.Checks.SymbolCheck" /> class.
@@ -20,10 +27,21 @@ namespace EzPasswordValidator.Checks
         /// <inheritdoc />
         /// <summary>
         /// Checks that the password contains at least one symbol.
-        /// Symbols are here defined as any character that is not a digit or
-        /// letter in the range A through Z.
         /// </summary>
-        protected override bool OnExecute(string password) =>
-            Regex.IsMatch(password, "^.*[^0-9A-Za-z].*$");
+        /// <remarks>
+        /// Note that this check only checks for the most common symbols, <see cref="SymbolsHashSet"/>.
+        /// </remarks>
+        protected override bool OnExecute(string password)
+        {
+            foreach (char c in password)
+            {
+                if (SymbolsHashSet.Contains(c))
+                {
+                    return true;
+                }   
+            }
+
+            return false;
+        }
     }
 }

--- a/source/EzPasswordValidator/Checks/SymbolRepetitionCheck.cs
+++ b/source/EzPasswordValidator/Checks/SymbolRepetitionCheck.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.RegularExpressions;
-
+﻿
 namespace EzPasswordValidator.Checks
 {
     /// <inheritdoc />
@@ -20,12 +19,42 @@ namespace EzPasswordValidator.Checks
 
         /// <inheritdoc />
         /// <summary>
-        /// Checks for immediate symbol repetition 3 or longer in sequence.
+        /// Checks for immediate symbol repetition 3 or longer in sequence. The check
+        /// is executed for symbols as defined in <see cref="SymbolCheck.SymbolsHashSet"/>.
         /// </summary>
         /// <returns>
         ///   <c>true</c> if the password does NOT contain symbol repetition; <c>false</c> otherwise.
         /// </returns>
-        protected override bool OnExecute(string password) =>
-            !Regex.IsMatch(password, @"^.*([^A-Za-z0-9])\1{2}.*$");
+        protected override bool OnExecute(string password)
+        {
+            const char baseSymbol = (char) 0;
+            char previousPrevious = baseSymbol;
+            char previous = baseSymbol;
+            foreach (char c in password)
+            {
+                if (SymbolCheck.SymbolsHashSet.Contains(c))
+                {
+                    if (previousPrevious == baseSymbol || previousPrevious != c)
+                    {
+                        previousPrevious = c;
+                    }else if (previous == baseSymbol || previous != c)
+                    {
+                        previous = c;
+                    }
+                    else
+                    {
+                        if (previousPrevious == previous && previous == c)
+                        {
+                            return false;
+                        }
+                    }
+                    continue;
+                }
+
+                previousPrevious = baseSymbol;
+                previous = baseSymbol;
+            }
+            return true;
+        }
     }
 }


### PR DESCRIPTION
# Description

The predefined checks now support other alphabets than ISO basic Latin.

Fixes #8 (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Multiple unit tests with non ISO basic latin letters.

**Test Configuration**:    
MSTest with Visual Studio

# Checklist:

- [x] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
