### PR TITLE
Password is now valid if no checks have been added, closes #14

### DIFF
--- a/source/EzPasswordValidator.Tests/PasswordValidatorTest.cs
+++ b/source/EzPasswordValidator.Tests/PasswordValidatorTest.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using EzPasswordValidator.Checks;
+using EzPasswordValidator.Validators;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace EzPasswordValidator.Tests
+{
+    [TestClass]
+    public class PasswordValidatorTest
+    {
+        private const CheckTypes OutOfRangeCheckType = (CheckTypes) (1 << 11);
+
+        private PasswordValidator _validator;
+
+        [TestInitialize]
+        public void Setup() => _validator = new PasswordValidator();
+
+        [TestMethod]
+        public void WhenValidatorHasNoChecksThenPasswordIsValid() => 
+            Assert.IsTrue(_validator.Validate("password"));
+
+        [TestMethod]
+        public void WhenAddingNonExistingCheckTypeThenExceptionIsThrown() => 
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => _validator.AddCheck(OutOfRangeCheckType));
+
+        [TestMethod]
+        public void WhenAddingNonExistingCheckTypeToConstructorThenExceptionIsThrown() => 
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new PasswordValidator(OutOfRangeCheckType));
+
+        [TestMethod]
+        public void WhenAddingCustomCheckWithAnExistingTagThenCheckIsNotAdded()
+        {
+            const string tag = "tag";
+
+            _validator.AddCheck(tag, (_) => false);
+            _validator.AddCheck(tag, (_) => true);
+
+            Assert.IsFalse(_validator.Validate("password"));
+        }
+
+        [TestMethod]
+        public void WhenAddingCheckByTypeThenCheckIsAdded()
+        {
+            _validator.AddCheck(CheckTypes.LetterSequence);
+
+            Check addedCheck = _validator.AllChecks.FirstOrDefault(_ => _.Type == CheckTypes.LetterSequence);
+
+            Assert.IsNotNull(addedCheck);
+        }
+
+        [TestMethod]
+        public void WhenRemovingNonExistingCheckTypeThenExceptionIsThrown() =>
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => _validator.RemoveCheck(OutOfRangeCheckType));
+
+        [TestMethod]
+        public void WhenRemovingByTagThenCheckIsRemoved()
+        {
+            const string tag = "tag";
+
+            _validator.AddCheck(tag, (_) => true);
+
+            int before = _validator.AllChecks.Count();
+
+            _validator.RemoveCheck(tag);
+
+            int after = _validator.AllChecks.Count();
+
+            Assert.AreEqual(after, before - 1);
+        }
+
+        [TestMethod]
+        public void WhenLengthCheckIsAddedAndUserChangesRequiredLengthThenLengthCheckIsUpdated()
+        {
+            _validator.AddCheck(CheckTypes.Length);
+
+            var checkBefore = (LengthCheck) _validator.AllChecks.FirstOrDefault(_ => _.Type == CheckTypes.Length);
+            Debug.Assert(checkBefore != null, nameof(checkBefore) + " != null");
+            uint lengthBefore = checkBefore.RequiredLength;
+
+            _validator.RequiredLength = lengthBefore + 1;
+
+            var checkAfter = (LengthCheck)_validator.AllChecks.FirstOrDefault(_ => _.Type == CheckTypes.Length);
+            Debug.Assert(checkAfter != null, nameof(checkAfter) + " != null");
+            uint lengthAfter = checkAfter.RequiredLength;
+
+            Assert.AreNotEqual(lengthBefore, lengthAfter);
+        }
+    }
+}

--- a/source/EzPasswordValidator/Validators/PasswordValidator.cs
+++ b/source/EzPasswordValidator/Validators/PasswordValidator.cs
@@ -23,7 +23,7 @@ namespace EzPasswordValidator.Validators
     /// {
     ///     foreach (Check failedCheck in validator.FailedChecks)
     ///     {
-    ///         //Inform user?
+    ///         
     ///     }
     /// }
     /// </code>
@@ -121,11 +121,13 @@ namespace EzPasswordValidator.Validators
         /// </summary>
         /// <param name="password">The password to check.</param>
         /// <returns>
-        ///   <c>true</c> if the password passes all checks; <c>false</c> otherwise.
+        ///   <c>true</c> if the password passes all checks; if no checks have been added
+        ///   then password is considered valid and <c>true</c> will be returned.
+        ///   If a check fails the password is invalid and <c>false</c> is returned.
         /// </returns>
         public bool Validate(string password)
         {
-            bool result = CheckTypes > CheckTypes.None;
+            var result = true;
             foreach (Check check in AllChecks)
             {
                 if (check.Execute(password) == false)
@@ -183,7 +185,7 @@ namespace EzPasswordValidator.Validators
         }
 
         /// <summary>
-        /// Adds the custom check.
+        /// Adds the custom check if a check with the given tag does not already exist.
         /// </summary>
         /// <param name="tag">
         ///   Unique string identifier.


### PR DESCRIPTION
# Description

Fixed a bug where a password would be considered invalid if there are no added tests.

Fixes #14, #3

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Includes unit tests

**Test Configuration**:    
MSTest in Visual Studio   

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
