### PR TITLE
Max password length can now be set, closes #12

### DIFF
--- a/source/EzPasswordValidator.Tests/PasswordValidatorTest.cs
+++ b/source/EzPasswordValidator.Tests/PasswordValidatorTest.cs
@@ -77,15 +77,18 @@ namespace EzPasswordValidator.Tests
 
             var checkBefore = (LengthCheck) _validator.AllChecks.FirstOrDefault(_ => _.Type == CheckTypes.Length);
             Debug.Assert(checkBefore != null, nameof(checkBefore) + " != null");
-            uint lengthBefore = checkBefore.RequiredLength;
+            uint minLenBefore = checkBefore.MinLength;
+            uint maxLenBefore = checkBefore.MaxLength;
 
-            _validator.RequiredLength = lengthBefore + 1;
+            _validator.SetLengthBounds(minLenBefore + 1, maxLenBefore + 1);
 
             var checkAfter = (LengthCheck)_validator.AllChecks.FirstOrDefault(_ => _.Type == CheckTypes.Length);
             Debug.Assert(checkAfter != null, nameof(checkAfter) + " != null");
-            uint lengthAfter = checkAfter.RequiredLength;
+            uint minLenAfter = checkBefore.MinLength;
+            uint maxLenAfter = checkBefore.MaxLength;
 
-            Assert.AreNotEqual(lengthBefore, lengthAfter);
+            Assert.AreNotEqual(minLenBefore, minLenAfter);
+            Assert.AreNotEqual(maxLenBefore, maxLenAfter);
         }
     }
 }

--- a/source/EzPasswordValidator/Checks/CheckFactory.cs
+++ b/source/EzPasswordValidator/Checks/CheckFactory.cs
@@ -12,11 +12,12 @@ namespace EzPasswordValidator.Checks
         /// Creates the a check for the specified check type.
         /// </summary>
         /// <param name="checkType">Type of check to generate.</param>
-        /// <param name="requiredLength">The minimum required length of the password.</param>
+        /// <param name="minLength">The minimum required length of the password.</param>
+        /// <param name="maxLength">The maximum allowed length of the password.</param>
         /// <returns>An instance of a <see cref="Check"/> object representing the given check type.</returns>
         /// <exception cref="InvalidEnumArgumentException">The check must only contain a single flag.</exception>
         /// <exception cref="ArgumentOutOfRangeException">No check found for the given argument.</exception>
-        public static Check Create(CheckTypes checkType, uint requiredLength)
+        public static Check Create(CheckTypes checkType, uint minLength, uint maxLength)
         {
             if (!checkType.IsSingleFlag())
             {
@@ -25,7 +26,7 @@ namespace EzPasswordValidator.Checks
             switch (checkType)
             {
                 case CheckTypes.Length:
-                    return new LengthCheck(requiredLength);
+                    return new LengthCheck(minLength, maxLength);
                 case CheckTypes.Numbers:
                     return new NumberCheck();
                 case CheckTypes.Letters:

--- a/source/EzPasswordValidator/Checks/LengthCheck.cs
+++ b/source/EzPasswordValidator/Checks/LengthCheck.cs
@@ -8,43 +8,48 @@
     public sealed class LengthCheck : Check
     {
         /// <summary>
-        /// The default required length of the password.
+        /// The default minimum length of the password.
         /// </summary>
-        public const uint DefaultLength = 8;
+        public const uint DefaultMinLength = 8;
+
+        /// <summary>
+        /// The default maximum length of the password.
+        /// </summary>
+        public const uint DefaultMaxLength = 128;
 
         /// <inheritdoc />
         /// <summary>
         /// Initializes a new instance of the <see cref="EzPasswordValidator.Checks.LengthCheck" /> class.
         /// </summary>
-        public LengthCheck() 
+        /// <param name="minLen">The minimum required length of the password.</param>
+        /// <param name="maxLen">The maximum allowed length of the password.</param>
+        public LengthCheck(uint minLen = DefaultMinLength, uint maxLen = DefaultMaxLength) 
             : base(CheckTypes.Length)
         {
-            RequiredLength = DefaultLength;
-        }
-
-        /// <inheritdoc />
-        /// <summary>
-        /// Initializes a new instance of the <see cref="EzPasswordValidator.Checks.LengthCheck" /> class.
-        /// </summary>
-        /// <param name="requiredLength">The required minimum length of the password.</param>
-        public LengthCheck(uint requiredLength)
-            : base(CheckTypes.Length)
-        {
-            RequiredLength = requiredLength;
+            MinLength = minLen;
+            MaxLength = maxLen;
         }
 
         /// <summary>
         /// Gets or sets the minimum required length of the password.
         /// </summary>
-        public uint RequiredLength { get; set; }
+        public uint MinLength { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum allowed length of the password.
+        /// </summary>
+        public uint MaxLength { get; set; }
 
         /// <inheritdoc />
         /// <summary>
-        /// Checks if the given password is equal to or longer than the required minimum length.
+        /// Checks if the given password is equal to or longer than the required minimum length
+        /// and equal to or shorter than the maximum length.
         /// The password is trimmed (trailing and leading white space is removed) before checking length.
         /// <c>null</c> is always invalid.
         /// </summary>
         protected override bool OnExecute(string password) =>
-            password != null && password.Trim().Length >= RequiredLength;
+            password != null && 
+            password.Trim().Length >= MinLength &&
+            password.Trim().Length <= MaxLength;
     }
 }

--- a/source/EzPasswordValidator/EzPasswordValidator.csproj
+++ b/source/EzPasswordValidator/EzPasswordValidator.csproj
@@ -3,16 +3,22 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageLicenseUrl>https://mit-license.org/</PackageLicenseUrl>
-    <Authors>Håvard T</Authors>
+    <Authors>havardt</Authors>
     <Company />
-    <PackageId>EzPasswordValidator_Havard_T</PackageId>
-    <Description>A .NET standard library for easy password validation.</Description>
-    <PackageProjectUrl></PackageProjectUrl>
+    <PackageId>EzPasswordValidator</PackageId>
+    <Description>A .NET standard library for easy password validation. This library defines 11 predefined checks and an easy way to implement custom checks.</Description>
+    <PackageProjectUrl>https://github.com/havardt/EzPasswordValidator</PackageProjectUrl>
     <RepositoryUrl>https://github.com/havardt/EzPasswordValidator</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageTags>Password Validator Library</PackageTags>
-    <SignAssembly>false</SignAssembly>
-    <Version>1.1.0</Version>
+    <PackageTags>Password Validator Library Checker EzPasswordValidator csharp password-validator easy</PackageTags>
+    <SignAssembly>true</SignAssembly>
+    <Version>1.3.0</Version>
+    <AssemblyVersion>1.3.0.0</AssemblyVersion>
+    <FileVersion>1.3.0.0</FileVersion>
+    <AssemblyOriginatorKeyFile>ezpasswordvalidator_key_file.pfx</AssemblyOriginatorKeyFile>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <PackageReleaseNotes />
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
# Description

Max password length can now be set, the default is 128 following the reccomendations set by the [OWASP cheat sheet](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Authentication_Cheat_Sheet.md).

Fixes #12

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Unit tests

**Test Configuration**:    
MSTest in Vistual Studio

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
