### PR TITLE
Min & max length bug fix, fixes #18

### DIFF
--- a/source/EzPasswordValidator.Tests/LengthCheckTest.cs
+++ b/source/EzPasswordValidator.Tests/LengthCheckTest.cs
@@ -1,4 +1,5 @@
 ﻿using EzPasswordValidator.Checks;
+using EzPasswordValidator.Validators;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace EzPasswordValidator.Tests
@@ -67,6 +68,20 @@ namespace EzPasswordValidator.Tests
             const string validPsw = "123456789123456789";
 
             Assert.IsTrue(_check.Execute(validPsw));
+        }
+
+        [TestMethod]
+        public void WhenUsingBasicCheckDefaultLengthsShouldApply()
+        {
+            const string validPsw = "abc123XYZ/";
+            const string invalidPsw = "Ab123/"; // Fits all criteria except minimum length.
+
+            var validator = new PasswordValidator(CheckTypes.Basic);
+
+            Assert.AreEqual(LengthCheck.DefaultMinLength, validator.MinLength);
+            Assert.AreEqual(LengthCheck.DefaultMaxLength, validator.MaxLength);
+            Assert.IsTrue(validator.Validate(validPsw));
+            Assert.IsFalse(validator.Validate(invalidPsw));
         }
     }
 }

--- a/source/EzPasswordValidator/Validators/PasswordValidator.cs
+++ b/source/EzPasswordValidator/Validators/PasswordValidator.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;  
+using System.Threading.Tasks;
 using EzPasswordValidator.Checks;
 
 namespace EzPasswordValidator.Validators
@@ -33,21 +33,21 @@ namespace EzPasswordValidator.Validators
     {
         private readonly Dictionary<CheckTypes, Check> _predefinedChecks = new Dictionary<CheckTypes, Check>();
         private readonly Dictionary<string, Check> _customChecks = new Dictionary<string, Check>();
-        private uint _minLength;
-        private uint _maxLength;
+        private uint _minLength = LengthCheck.DefaultMinLength;
+        private uint _maxLength = LengthCheck.DefaultMaxLength;
 
         /// <inheritdoc />
-        public PasswordValidator() 
+        public PasswordValidator()
             : this(CheckTypes.None)
         {
-            
+
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PasswordValidator"/> class.
         /// </summary>
         /// <param name="checkTypes">Initial check types.</param>
-        public PasswordValidator(CheckTypes checkTypes) 
+        public PasswordValidator(CheckTypes checkTypes)
         {
             AddCheck(checkTypes);
         }
@@ -146,8 +146,8 @@ namespace EzPasswordValidator.Validators
             }
             return result;
         }
-		
-		/// <summary>
+
+        /// <summary>
         /// Validates the specified password asynchronous. This method should be used
         /// when custom checks include long running operations.
         /// </summary>
@@ -171,7 +171,7 @@ namespace EzPasswordValidator.Validators
         /// <exception cref="ArgumentOutOfRangeException">The given value does not represent any <see cref="CheckTypes"/>.</exception>
         public void AddCheck(CheckTypes checkTypes)
         {
-            if(!checkTypes.IsInRange())
+            if (!checkTypes.IsInRange())
             {
                 throw new ArgumentOutOfRangeException($"No checks within the given value: {checkTypes}");
             }
@@ -225,7 +225,7 @@ namespace EzPasswordValidator.Validators
         /// </summary>
         /// <param name="checkTypes">An <see cref="Int32"/> value representing check types.</param>
         /// <exception cref="ArgumentOutOfRangeException">The given value does not represent any <see cref="CheckTypes"/>.</exception>
-        public void RemoveCheck(int checkTypes) => RemoveCheck((CheckTypes) checkTypes);
+        public void RemoveCheck(int checkTypes) => RemoveCheck((CheckTypes)checkTypes);
 
         /// <summary>
         /// Removes the custom check.
@@ -294,6 +294,6 @@ namespace EzPasswordValidator.Validators
                 }
             }
         }
-       
+
     }
 }


### PR DESCRIPTION
# Description

There was a bug where minimum and maximum length was not implicitly enforced, the user had to explicitly set the minimum and maximum length even if one wanted to use the default length bounds.

Fixes #18 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

